### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-discovery-news.svg?branch=master)](https://travis-ci.org/IBM/watson-discovery-news)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/c58bea8bac2a6faa8d98e3d6c6cb9320/badge.svg)
 
 # Query Watson Discovery News using the Watson Discovery Service
 
@@ -52,7 +51,7 @@ Optionally included will be examples of how to:
 Use the ``Deploy to IBM Cloud`` button **OR** create the services and run locally.
 
 ## Deploy to IBM Cloud
-[![Deploy to IBM Cloud](https://metrics-tracker.mybluemix.net/stats/c58bea8bac2a6faa8d98e3d6c6cb9320/button.svg)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-news.git)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-discovery-news.git)
 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy``.
 
@@ -198,28 +197,6 @@ If the port is unavailable, you will see the following error:
 ```
 Error: listen EADDRINUSE :::{port}
 ```
-
-# Privacy Notice
-
-If using the Deploy to IBM Cloud button some metrics are tracked, the following information is sent to a [Deployment Tracker](https://github.com/IBM-Bluemix/cf-deployment-tracker-service) service
-on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` file in the sample application and the ``VCAP_APPLICATION`` and ``VCAP_SERVICES`` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove `require("metrics-tracker-client").track();` from the ``app.js`` file in the top level directory.
 
 # Links
 * [Demo on Youtube](https://youtu.be/EZGgvci9nC0): Watch the video.

--- a/app.js
+++ b/app.js
@@ -15,7 +15,6 @@
  */
 
 require('dotenv').config({ silent: true });
-require('metrics-tracker-client').track();
 
 const server = require('./server');
 const port = process.env.PORT || process.env.VCAP_APP_PORT || 3000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8381,32 +8381,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "metrics-tracker-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/metrics-tracker-client/-/metrics-tracker-client-0.2.3.tgz",
-      "integrity": "sha512-AtTxMSz4ypCpUBmu8lhnJ609TSFenKUgIdbsopac7l6/TFsKQZGB9W8D7yXLzeVvev0LKrqWzLHtH0XTeUcxeQ==",
-      "requires": {
-        "cwd": "0.10.0",
-        "js-yaml": "3.10.0",
-        "restler": "3.4.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
-          }
-        }
-      }
-    },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "express": "^4.15.3",
     "express-browserify": "^1.0.2",
     "express-react-views": "^0.10.2",
-    "metrics-tracker-client": "*",
     "moment": "^2.18.1",
     "prop-types": "^15.5.10",
     "query-string": "^4.3.4",


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. `require('metrics-tracker-client').track();`
package.json for metrics-tracker
package-lock.json stuff

Change D2B to:
https://bluemix.net/deploy/button.png