### PR TITLE
Add buttons for deployment and Openshift instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,113 +52,13 @@ This code pattern shows you how to tap into massive data sets to mine insight. Y
 
 [![](https://img.youtube.com/vi/EZGgvci9nC0/0.jpg)](https://youtu.be/EZGgvci9nC0)
 
-# Steps
+## Deployment options
 
-Use the **Deploy to IBM Cloud** button **OR** create the services and run locally.
+Click on one of the options below for instructions on deploying the app.
 
-## Deploy to IBM Cloud
-
-[![Deploy to IBM Cloud](https://cloud.ibm.com/devops/setup/deploy/button.png)](https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/IBM/watson-discovery-news)
-
-1. Press the **Deploy to IBM Cloud** button and then click on the **Deploy** option. Remember to create an IBM Cloud API key if required.
-
-![deploy](doc/source/images/deploy.png)
-
-2. From the Toolchains view, click on the Delivery Pipeline to watch while the app is deployed. Here you'll be able to see logs about the deployment.
-
-![toolchain-pipeline](doc/source/images/toolchain-pipeline.png)
-
-3. To see the app and services that were created use the [IBM Cloud dashboard](https://cloud.ibm.com). The app is named `watson-discovery-news` with a unique suffix. The following services are created:
-
-    * discovery-news-service
-
-## Run locally
-
-> NOTE: These steps are only needed when running locally instead of using the ``Deploy to IBM Cloud`` button.
-
-1. [Clone the repo](#1-clone-the-repo)
-1. [Create your Watson Discovery service](#2-create-your-watson-discovery-service)
-1. [Configure Watson Discovery](#3-configure-watson-discovery)
-1. [Add Watson Discovery credentials](#4-add-watson-discovery-credentials)
-1. [Run the application](#5-run-the-application)
-
-## 1. Clone the repo
-
-Use the following command to clone the watson-discovery-news GitHub repository.
-
-```bash
-git clone https://github.com/ibm/watson-discovery-news
-```
-
-## 2. Create your Watson Discovery service
-
-To create your Watson Discovery service:
-
-  1. Click **Create resource** on your IBM Cloud dashboard.
-
-  2. Search the catalog for **Discovery**.
-
-  3. Click **Discovery** to launch the create panel.
-
-![create-service](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/discover-service-create.png)
-
-  4. From the panel, enter a unique name, a region and resource group, and a plan type (select the default **lite** plan). Click **Create** to create and enable your service.
-
-## 3. Configure Watson Discovery
-
-The next step is to configure your Watson Discovery service.
-
-  1. Find the Discovery service in your IBM Cloud Dashboard.
-  2. Click on the service and then click **Launch tool**.
-
-The Watson Discovery News data collection is already associated with your service. You'll use this collection as the data source for your app. To access the collection, you must find the `COLLECTION_ID` and `ENVIRONMENT_ID`. To find these values:
-
-  1. Click on the collection from the Manage Data panel. In this case, it is named `Watson Discovery News`.
-  2. Click on the drop-down icon located in the top right corner of the panel.
-
-![get-collection-id](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-collection-id.png)
-
-Typically, these values need to be added to the application .env file (as shown in the next step), but in the case of `Discovery News`, the values are always `news-en` (though it might vary based on language) and `system`, so you do not need to specify them.
-
-## 4. Add Watson Discovery credentials
-
-Next, you'll need to add the Watson Discovery credentials to the .env file.
-
-  1. From the home directory of your cloned local repo, create a .env file by copying it from the sample version.
-
-<!--remove these HTML tags when series gets support for markdown code blocks -->
-<div class="bx--snippet bx--snippet--multi bx--snippet-btn--expand--hide" data-code-snippet="">
-  <div class="bx--snippet-container" aria-label="Code Snippet Text">
-  <pre><code>
-cp env.sample .env
-  </pre></code>
-  </div>
-</div>
-
-  2. Locate the service credentials listed on the home page of your Discovery service.
-
-![get-creds](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-creds.png)
-
-  3. Copy and paste the `apikey` and `URL` values from your Watson Discovery service credentials into the .env file:
-
-```bash
-# Watson Discovery
-DISCOVERY_URL=<add_discovery_url>
-DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
-DISCOVERY_ENVIRONMENT_ID=system
-DISCOVERY_COLLECTION_ID=news-en
-```
-
-### 5. Run the application
-
-Finally, you'll run the application.
-
-```bash
-npm install
-npm start
-```
-
-The application will be available in your browser at `http://localhost:3000`.
+|   |   |   |
+| - | - | - |
+| [![public](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/cf.png)](doc/source/cf.md) | [![openshift](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/openshift.png)](doc/source/openshift.md) | [![local](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/local.png)](doc/source/local.md) |
 
 ## Sample output
 

--- a/doc/source/cf.md
+++ b/doc/source/cf.md
@@ -1,0 +1,25 @@
+# Run on IBM Cloud with Cloud Foundry
+
+This document shows how to run the `watson-discovery-news` application using Cloud Foundry on IBM Cloud.
+
+## Steps
+
+<p align="center">
+    <a href="https://cloud.ibm.com/devops/setup/deploy?repository=https://github.com/IBM/watson-discovery-news">
+    <img src="https://cloud.ibm.com/devops/setup/deploy/button_x2.png" alt="Deploy to IBM Cloud">
+    </a>
+</p>
+
+1. Click the `Deploy to IBM Cloud` button and hit `Create` on the next prompt. This will automatically create the services and application for you. Create an IBM Cloud API key if required.
+
+![deploy](images/deploy.png)
+
+2. From the Toolchains view, click on the Delivery Pipeline to watch while the app is deployed. Here you'll be able to see logs about the deployment.
+
+![toolchain-pipeline](images/toolchain-pipeline.png)
+
+3. To see the app and services that were created use the [IBM Cloud dashboard](https://cloud.ibm.com). The app is named `watson-discovery-news` with a unique suffix. The following services are created:
+
+    * discovery-news-service
+
+[![return](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/return.png)](https://github.com/IBM/watson-discovery-news#sample-output)

--- a/doc/source/local.md
+++ b/doc/source/local.md
@@ -1,0 +1,90 @@
+# Run locally
+
+This document shows how to run the `watson-discovery-news` application on your local machine.
+
+## Steps
+
+1. [Clone the repo](#1-clone-the-repo)
+1. [Create your Watson Discovery service](#2-create-your-watson-discovery-service)
+1. [Configure Watson Discovery](#3-configure-watson-discovery)
+1. [Add Watson Discovery credentials](#4-add-watson-discovery-credentials)
+1. [Run the application](#5-run-the-application)
+
+## 1. Clone the repo
+
+Use the following command to clone the watson-discovery-news GitHub repository.
+
+```bash
+git clone https://github.com/ibm/watson-discovery-news
+```
+
+## 2. Create your Watson Discovery service
+
+To create your Watson Discovery service:
+
+  1. Click **Create resource** on your IBM Cloud dashboard.
+
+  2. Search the catalog for **Discovery**.
+
+  3. Click **Discovery** to launch the create panel.
+
+![create-service](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/discover-service-create.png)
+
+  4. From the panel, enter a unique name, a region and resource group, and a plan type (select the default **lite** plan). Click **Create** to create and enable your service.
+
+## 3. Configure Watson Discovery
+
+The next step is to configure your Watson Discovery service.
+
+  1. Find the Discovery service in your IBM Cloud Dashboard.
+  2. Click on the service and then click **Launch tool**.
+
+The Watson Discovery News data collection is already associated with your service. You'll use this collection as the data source for your app. To access the collection, you must find the `COLLECTION_ID` and `ENVIRONMENT_ID`. To find these values:
+
+  1. Click on the collection from the Manage Data panel. In this case, it is named `Watson Discovery News`.
+  2. Click on the drop-down icon located in the top right corner of the panel.
+
+![get-collection-id](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-collection-id.png)
+
+Typically, these values need to be added to the application .env file (as shown in the next step), but in the case of `Discovery News`, the values are always `news-en` (though it might vary based on language) and `system`, so you do not need to specify them.
+
+## 4. Add Watson Discovery credentials
+
+Next, you'll need to add the Watson Discovery credentials to the .env file.
+
+  1. From the home directory of your cloned local repo, create a .env file by copying it from the sample version.
+
+<!--remove these HTML tags when series gets support for markdown code blocks -->
+<div class="bx--snippet bx--snippet--multi bx--snippet-btn--expand--hide" data-code-snippet="">
+  <div class="bx--snippet-container" aria-label="Code Snippet Text">
+  <pre><code>
+cp env.sample .env
+  </pre></code>
+  </div>
+</div>
+
+  2. Locate the service credentials listed on the home page of your Discovery service.
+
+![get-creds](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-creds.png)
+
+  3. Copy and paste the `apikey` and `URL` values from your Watson Discovery service credentials into the .env file:
+
+```bash
+# Watson Discovery
+# Change the URL and uncomment if it is different from below:
+# DISCOVERY_URL=https://gateway.watsonplatform.net/discovery/api
+DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
+```
+
+### 5. Run the application
+
+Finally, you'll run the application.
+
+```bash
+npm install
+npm start
+```
+
+The application will be available in your browser at `http://localhost:3000`.
+
+[![return](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/return.png)](https://github.com/IBM/watson-discovery-news#sample-output)

--- a/doc/source/openshift.md
+++ b/doc/source/openshift.md
@@ -1,0 +1,78 @@
+# Run on RedHat OpenShift
+
+This document shows how to run the `watson-discovery-news` application in a container running on RedHat OpenShift.
+
+## Prerequisites
+
+You will need a running OpenShift cluster, or OKD cluster. You can provision [OpenShift on the IBM Cloud](https://cloud.ibm.com/kubernetes/catalog/openshiftcluster).
+
+## Steps
+
+* In your cluster, open your project or click on `+ Create Project` to create one.
+* In the `Overview` tab, click on `Browse Catalog`
+
+![Browse Catalog](https://github.com/IBM/pattern-utils/blob/master/openshift/openshift-browse-catalog.png)
+
+* Choose the `Node.js` app container and click `Next`.
+
+![Choose Node.js](https://github.com/IBM/pattern-utils/blob/master/openshift/openshift-choose-nodejs.png)
+
+* Give your app a name and add `https://github.com/IBM/watson-discovery-news` for the github repo, then click `Create`.
+
+![Add github repo](https://github.com/IBM/pattern-utils/blob/master/openshift/openshift-add-github-repo.png)
+
+### Create your Watson Discovery service
+
+To create your Watson Discovery service:
+
+  1. Click **Create resource** on your IBM Cloud dashboard.
+
+  2. Search the catalog for **Discovery**.
+
+  3. Click **Discovery** to launch the create panel.
+
+![create-service](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/discover-service-create.png)
+
+From the panel, enter a unique name, a region and resource group, and a plan type (select the default **lite** plan). Click **Create** to create and enable your service.
+
+### Configure Watson Discovery
+
+The next step is to configure your Watson Discovery service.
+
+  1. Find the Discovery service in your IBM Cloud Dashboard.
+  2. Click on the service and then click **Launch tool**.
+
+The Watson Discovery News data collection is already associated with your service. You'll use this collection as the data source for your app. To access the collection, you must find the `COLLECTION_ID` and `ENVIRONMENT_ID`. To find these values:
+
+  1. Click on the collection from the Manage Data panel. In this case, it is named `Watson Discovery News`.
+  2. Click on the drop-down icon located in the top right corner of the panel.
+
+![get-collection-id](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-collection-id.png)
+
+Typically, these values need to be added to the application .env file (as shown in the next step), but in the case of `Discovery News`, the values are always `news-en` (though it might vary based on language) and `system`, so you do not need to specify them.
+
+### Create the config map
+
+* You will need to export the key/value pairs from [env.sample](../../env.sample) as a config map.
+
+* Locate the service credentials listed on the home page of your Discovery service.
+
+![get-creds](https://raw.githubusercontent.com/IBM/pattern-utils/master/watson-discovery/get-creds.png)
+
+Copy the `apikey` value from your Watson Discovery service credentials.
+
+* Back in the OpenShift or OKD UI, click on the `Resources` tab and choose `Config Maps` and then `Create Config Map`.
+
+* Add a key for `DISCOVERY_IAM_APIKEY` and past in the `apikey` value as `value`:
+
+![add config map](https://github.com/IBM/pattern-utils/blob/master/openshift/openshift-generic-config-map.png)
+
+* Click `Add item` and then add a key for `PORT` with the value `8080`.
+
+* Go to the `Applications` tab, choose `Deployments` and the `Environment` tab. Under `Environment From` `Config Map/Secret` choose the config map you just created [1]. Save the config [2]. The app will re-deploy automatically, or click `Deploy` to re-deploy manually [3]. To see the variables in the Config Map that will be exported in the app environment, click `View Details`.
+
+![add config map to app](https://github.com/IBM/pattern-utils/blob/master/openshift/openshift-add-config-map-to-app.png)
+
+* Under `Applications` -> `Routes` you will see your app. Click on the `Hostname` to see your Watson Discovery News app in action.
+
+[![return](https://raw.githubusercontent.com/IBM/pattern-utils/master/deploy-buttons/return.png)](https://github.com/IBM/watson-discovery-news#sample-output)

--- a/env.sample
+++ b/env.sample
@@ -2,7 +2,8 @@
 # your own before starting the app.
 
 # Watson Discovery
-DISCOVERY_URL=<add_discovery_url>
+# Change the URL and uncomment if it is different from below:
+# DISCOVERY_URL=https://gateway.watsonplatform.net/discovery/api
 DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
 
 # Run locally on a non-default port (default is 3000)
@@ -10,6 +11,3 @@ DISCOVERY_IAM_APIKEY=<add_discovery_iam_apikey>
 
 # Slack
 SLACK_BOT_TOKEN=<slack_bot_token>
-
-# Run locally on a non-default port (default is 3000)
-# PORT=3000


### PR DESCRIPTION
Change README.md to use buttons to navigate to deployment options.
Pull out `local.md` and `cf.md` as instructions for local deploy
and Cloud Foundry deploy.
Add `openshift.md` for Openshift deploy.
Remove `DISCOVERY_URL` from `env.sample` because it is not needed.